### PR TITLE
🔒️ Fix XSS in datagrid and translations on admin side

### DIFF
--- a/src/Backend/Modules/Commerce/Actions/StockStatuses.php
+++ b/src/Backend/Modules/Commerce/Actions/StockStatuses.php
@@ -6,9 +6,6 @@ use Backend\Core\Engine\Base\ActionIndex as BackendBaseActionIndex;
 use Backend\Core\Language\Locale;
 use Backend\Modules\Commerce\Domain\StockStatus\DataGrid;
 
-/**
- * This is the vats action, it will display the overview of vats.
- */
 class StockStatuses extends BackendBaseActionIndex
 {
     public function execute(): void

--- a/src/Backend/Modules/Commerce/Domain/Brand/DataGrid.php
+++ b/src/Backend/Modules/Commerce/Domain/Brand/DataGrid.php
@@ -27,6 +27,7 @@ class DataGrid extends DataGridDatabase
         // sequence
         $this->enableSequenceByDragAndDrop();
         $this->setAttributes(['data-action' => 'SequenceBrands']);
+        $this->setColumnFunction('htmlspecialchars', ['[title]'], 'title', false);
 
         // check if this action is allowed
         if (BackendAuthentication::isAllowedAction('EditBrand')) {

--- a/src/Backend/Modules/Commerce/Domain/CartRule/DataGrid.php
+++ b/src/Backend/Modules/Commerce/Domain/CartRule/DataGrid.php
@@ -24,6 +24,9 @@ class DataGrid extends DataGridDatabase
             ['language' => $locale]
         );
 
+        $this->setColumnFunction('htmlspecialchars', ['[title]'], 'title', false);
+        $this->setColumnFunction('htmlspecialchars', ['[discountCode]'], 'discountCode', false);
+
         // check if this action is allowed
         if (BackendAuthentication::isAllowedAction('EditCartRule')) {
             $editUrl = Model::createUrlForAction('EditCartRule', null, null, ['id' => '[id]'], false);

--- a/src/Backend/Modules/Commerce/Domain/Category/DataGrid.php
+++ b/src/Backend/Modules/Commerce/Domain/Category/DataGrid.php
@@ -40,6 +40,7 @@ class DataGrid extends DataGridDatabase
         // sequence
         $this->enableSequenceByDragAndDrop();
         $this->setAttributes(['data-action' => 'SequenceCategories']);
+        $this->setColumnFunction('htmlspecialchars', ['[title]'], 'title', false);
 
         // check if this action is allowed
         if (BackendAuthentication::isAllowedAction('EditCategory')) {

--- a/src/Backend/Modules/Commerce/Domain/Country/DataGrid.php
+++ b/src/Backend/Modules/Commerce/Domain/Country/DataGrid.php
@@ -22,6 +22,9 @@ class DataGrid extends DataGridDatabase
             ['language' => $locale]
         );
 
+        $this->setColumnFunction('htmlspecialchars', ['[name]'], 'name', false);
+        $this->setColumnFunction('htmlspecialchars', ['[iso_code]'], 'iso_code', false);
+
         // check if this action is allowed
         if (BackendAuthentication::isAllowedAction('EditCountry')) {
             $editUrl = Model::createUrlForAction('EditCountry', null, null, ['id' => '[id]'], false);

--- a/src/Backend/Modules/Commerce/Domain/Order/DataGrid.php
+++ b/src/Backend/Modules/Commerce/Domain/Order/DataGrid.php
@@ -73,6 +73,10 @@ class DataGrid extends DataGridDatabase
         parent::__construct($query, $params);
 
         // assign column functions
+        $this->setColumnFunction('htmlspecialchars', ['[name]'], 'name', false);
+        $this->setColumnFunction('htmlspecialchars', ['[orderStatus]'], 'orderStatus', false);
+        $this->setColumnFunction('htmlspecialchars', ['[orderStatusColor]'], 'orderStatusColor', false);
+        $this->setColumnFunction('htmlspecialchars', ['[companyName]'], 'companyName', false);
         $this->setColumnsHidden(['companyName', 'orderNumber', 'orderStatusColor']);
         $this->setColumnFunction([new DataGridFunctions(), 'getLongDate'], '[orderDate]', 'orderDate', true);
         $this->setColumnFunction([self::class, 'getFormattedMoney'], ['[total]', '[totalCurrencyCode]'], 'total', true);

--- a/src/Backend/Modules/Commerce/Domain/Order/DataGridOrderHistory.php
+++ b/src/Backend/Modules/Commerce/Domain/Order/DataGridOrderHistory.php
@@ -24,6 +24,7 @@ class DataGridOrderHistory extends DataGridDatabase
 
         // assign column functions
         $this->setColumnFunction([new DataGridFunctions(), 'getDate'], '[date]', 'date', true);
+        $this->setColumnFunction('htmlspecialchars', ['[title]'], 'title', false);
     }
 
     public static function getHtml(Order $order): string

--- a/src/Backend/Modules/Commerce/Domain/Order/DataGridProducts.php
+++ b/src/Backend/Modules/Commerce/Domain/Order/DataGridProducts.php
@@ -38,6 +38,8 @@ class DataGridProducts extends DataGridDatabase
 
         // assign column functions
         $this->setColumnHidden('id');
+        $this->setColumnFunction('htmlspecialchars', ['[product]'], 'product', false);
+        $this->setColumnFunction('htmlspecialchars', ['[sku]'], 'sku', false);
         $this->setColumnFunction([self::class, 'getProductOptions'], ['[product]', '[id]'], 'product', true);
         $this->setColumnFunction([self::class, 'getFormattedMoney'], ['[total]', '[totalCurrencyCode]'], 'total', true);
         $this->setColumnFunction([self::class, 'getFormattedMoney'], ['[price]', '[priceCurrencyCode]'], 'price', true);

--- a/src/Backend/Modules/Commerce/Domain/OrderStatus/DataGrid.php
+++ b/src/Backend/Modules/Commerce/Domain/OrderStatus/DataGrid.php
@@ -24,6 +24,9 @@ class DataGrid extends DataGridDatabase
             ['language' => $locale]
         );
 
+        $this->setColumnFunction('htmlspecialchars', ['[title]'], 'title', false);
+        $this->setColumnFunction('htmlspecialchars', ['[color]'], 'color', false);
+
         // check if this action is allowed
         if (BackendAuthentication::isAllowedAction('EditOrderStatus')) {
             $editUrl = Model::createUrlForAction('EditOrderStatus', null, null, ['id' => '[id]'], false);

--- a/src/Backend/Modules/Commerce/Domain/PaymentMethod/DataGrid.php
+++ b/src/Backend/Modules/Commerce/Domain/PaymentMethod/DataGrid.php
@@ -27,13 +27,11 @@ class DataGrid extends DataGridArray
         // our JS needs to know an id, so we can highlight it
         $this->setRowAttributes(['id' => 'row-[id]']);
 
-        // Add some columns
-        $this->setColumnFunction(
-            [new DataGridFunctions(), 'showBool'],
-            ['[isEnabled]'],
-            'isEnabled',
-            true
-        );
+        // Modify column values
+        $this->setColumnFunction('htmlspecialchars', ['[name]'], 'name', false);
+        $this->setColumnFunction('htmlspecialchars', ['[description]'], 'description', false);
+        $this->setColumnFunction('htmlspecialchars', ['[version]'], 'version', false);
+        $this->setColumnFunction([new DataGridFunctions(), 'showBool'], ['[isEnabled]'], 'isEnabled', true);
 
         // Overwrite header labels
         $this->setHeaderLabels(

--- a/src/Backend/Modules/Commerce/Domain/Product/DataGrid.php
+++ b/src/Backend/Modules/Commerce/Domain/Product/DataGrid.php
@@ -74,6 +74,12 @@ class DataGrid extends DataGridDatabase
             ]
         );
 
+        // Escape values
+        $this->setColumnFunction('htmlspecialchars', ['[title]'], 'title', false);
+        $this->setColumnFunction('htmlspecialchars', ['[sku]'], 'sku', false);
+        $this->setColumnFunction('htmlspecialchars', ['[brand]'], 'brand', false);
+
+
         // our JS needs to know an id, so we can highlight it
         $this->setRowAttributes(['id' => 'row-[id]']);
         $this->setColumnsHidden(['sequence', 'priceCurrencyCode']);

--- a/src/Backend/Modules/Commerce/Domain/ProductOption/DataGrid.php
+++ b/src/Backend/Modules/Commerce/Domain/ProductOption/DataGrid.php
@@ -36,6 +36,7 @@ class DataGrid extends DataGridDatabase
 
         // our JS needs to know an id, so we can highlight it
         $this->setRowAttributes(['id' => 'row-[id]']);
+        $this->setColumnFunction('htmlspecialchars', ['[title]'], 'title', false);
         $this->setColumnFunction([DataGridFunctions::class, 'showBool'], ['[required]'], 'required');
         $this->setColumnFunction([DataGridFunctions::class, 'showBool'], ['[customValueAllowed]'], 'customValueAllowed');
         $this->setColumnFunction([self::class, 'getType'], ['[type]'], 'type');

--- a/src/Backend/Modules/Commerce/Domain/ProductOptionValue/DataGrid.php
+++ b/src/Backend/Modules/Commerce/Domain/ProductOptionValue/DataGrid.php
@@ -38,6 +38,7 @@ class DataGrid extends DataGridDatabase
         );
 
         // Data grid options
+        $this->setColumnFunction('htmlspecialchars', ['[title]'], 'title', false);
         $this->setColumnFunction([DataGridFunctions::class, 'showBool'], ['[defaultValue]'], 'defaultValue');
         $this->setColumnFunction([self::class, 'getImpactTypeText'], ['[impactType]'], 'impactType');
         $this->setColumnsHidden(['sequence']);

--- a/src/Backend/Modules/Commerce/Domain/ShipmentMethod/DataGrid.php
+++ b/src/Backend/Modules/Commerce/Domain/ShipmentMethod/DataGrid.php
@@ -28,12 +28,10 @@ class DataGrid extends DataGridArray
         $this->setRowAttributes(['id' => 'row-[id]']);
 
         // Add some columns
-        $this->setColumnFunction(
-            [new DataGridFunctions(), 'showBool'],
-            ['[isEnabled]'],
-            'isEnabled',
-            true
-        );
+        $this->setColumnFunction('htmlspecialchars', ['[name]'], 'name', false);
+        $this->setColumnFunction('htmlspecialchars', ['[description]'], 'description', false);
+        $this->setColumnFunction('htmlspecialchars', ['[version]'], 'version', false);
+        $this->setColumnFunction([new DataGridFunctions(), 'showBool'], ['[isEnabled]'], 'isEnabled', true);
 
         // Overwrite header labels
         $this->setHeaderLabels(

--- a/src/Backend/Modules/Commerce/Domain/Specification/DataGrid.php
+++ b/src/Backend/Modules/Commerce/Domain/Specification/DataGrid.php
@@ -29,12 +29,8 @@ class DataGrid extends DataGridDatabase
         $this->setAttributes(['data-action' => 'SequenceSpecifications']);
 
         // Add some columns
-        $this->setColumnFunction(
-            [new DataGridFunctions(), 'showBool'],
-            ['[filter]'],
-            'filter',
-            true
-        );
+        $this->setColumnFunction('htmlspecialchars', ['[specification]'], 'specification', false);
+        $this->setColumnFunction([new DataGridFunctions(), 'showBool'], ['[filter]'], 'filter', true);
 
         // Overwrite header labels
         $this->setHeaderLabels(

--- a/src/Backend/Modules/Commerce/Domain/SpecificationValue/DataGrid.php
+++ b/src/Backend/Modules/Commerce/Domain/SpecificationValue/DataGrid.php
@@ -28,6 +28,7 @@ class DataGrid extends DataGridDatabase
         // sequence
         $this->enableSequenceByDragAndDrop();
         $this->setAttributes(['data-action' => 'SequenceSpecificationValues']);
+        $this->setColumnFunction('htmlspecialchars', ['[value]'], 'value', false);
 
         // check if this action is allowed
         if (BackendAuthentication::isAllowedAction('EditSpecificationValue')) {

--- a/src/Backend/Modules/Commerce/Domain/StockStatus/DataGrid.php
+++ b/src/Backend/Modules/Commerce/Domain/StockStatus/DataGrid.php
@@ -24,6 +24,8 @@ class DataGrid extends DataGridDatabase
             ['language' => $locale]
         );
 
+        $this->setColumnFunction('htmlspecialchars', ['[title]'], 'title', false);
+
         // check if this action is allowed
         if (BackendAuthentication::isAllowedAction('EditStockStatus')) {
             $editUrl = Model::createUrlForAction('EditStockStatus', null, null, ['id' => '[id]'], false);

--- a/src/Backend/Modules/Commerce/Domain/Vat/DataGrid.php
+++ b/src/Backend/Modules/Commerce/Domain/Vat/DataGrid.php
@@ -26,6 +26,7 @@ class DataGrid extends DataGridDatabase
         // sequence
         $this->enableSequenceByDragAndDrop();
         $this->setAttributes(['data-action' => 'SequenceVats']);
+        $this->setColumnFunction('htmlspecialchars', ['[title]'], 'title', false);
 
         // check if this action is allowed
         if (BackendAuthentication::isAllowedAction('EditVat')) {

--- a/src/Backend/Modules/Commerce/Layout/Templates/Edit.html.twig
+++ b/src/Backend/Modules/Commerce/Layout/Templates/Edit.html.twig
@@ -242,7 +242,7 @@
             <span class="modal-title h4">{{ 'lbl.Delete'|trans|ucfirst }}</span>
           </div>
           <div class="modal-body">
-            <p>{{ 'msg.ConfirmDelete'|trans|format(product.title)|raw }}</p>
+            <p>{{ 'msg.ConfirmDelete'|trans|format(product.title|escape)|raw }}</p>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-default" data-dismiss="modal">
@@ -269,7 +269,7 @@
             <span class="modal-title h4">{{ 'lbl.Copy'|trans|ucfirst }}</span>
           </div>
           <div class="modal-body">
-            <p>{{ 'Weet je zeker dat je "%s" wilt kopieëren naar een nieuw product?'|trans|format(product.title)|raw }}</p>
+            <p>{{ 'Weet je zeker dat je "%s" wilt kopiëren naar een nieuw product?'|trans|format(product.title|escape)|raw }}</p>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-default" data-dismiss="modal">

--- a/src/Backend/Modules/Commerce/Layout/Templates/EditBrand.html.twig
+++ b/src/Backend/Modules/Commerce/Layout/Templates/EditBrand.html.twig
@@ -63,7 +63,7 @@
                         <span class="modal-title h4">{{ 'lbl.Delete'|trans|ucfirst }}</span>
                     </div>
                     <div class="modal-body">
-                        <p>{{ 'msg.ConfirmDelete'|trans|format(brand.title)|raw }}</p>
+                        <p>{{ 'msg.ConfirmDelete'|trans|format(brand.title|escape)|raw }}</p>
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-default" data-dismiss="modal">

--- a/src/Backend/Modules/Commerce/Layout/Templates/EditCartRule.html.twig
+++ b/src/Backend/Modules/Commerce/Layout/Templates/EditCartRule.html.twig
@@ -54,7 +54,7 @@
             <span class="modal-title h4">{{ 'lbl.Delete'|trans|ucfirst }}</span>
           </div>
           <div class="modal-body">
-            <p>{{ 'msg.ConfirmDelete'|trans|format(cartRule.title)|raw }}</p>
+            <p>{{ 'msg.ConfirmDelete'|trans|format(cartRule.title|escape)|raw }}</p>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-default" data-dismiss="modal">

--- a/src/Backend/Modules/Commerce/Layout/Templates/EditCategory.html.twig
+++ b/src/Backend/Modules/Commerce/Layout/Templates/EditCategory.html.twig
@@ -98,7 +98,7 @@
             <span class="modal-title h4">{{ 'lbl.Delete'|trans|ucfirst }}</span>
           </div>
           <div class="modal-body">
-            <p>{{ 'msg.ConfirmDelete'|trans|format(category.title)|raw }}</p>
+            <p>{{ 'msg.ConfirmDelete'|trans|format(category.title|escape)|raw }}</p>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-default" data-dismiss="modal">

--- a/src/Backend/Modules/Commerce/Layout/Templates/EditCountry.html.twig
+++ b/src/Backend/Modules/Commerce/Layout/Templates/EditCountry.html.twig
@@ -56,7 +56,7 @@
                         <span class="modal-title h4">{{ 'lbl.Delete'|trans|ucfirst }}</span>
                     </div>
                     <div class="modal-body">
-                        <p>{{ 'msg.ConfirmDelete'|trans|format(country.title)|raw }}</p>
+                        <p>{{ 'msg.ConfirmDelete'|trans|format(country.title|escape)|raw }}</p>
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-default" data-dismiss="modal">

--- a/src/Backend/Modules/Commerce/Layout/Templates/EditOrderStatus.html.twig
+++ b/src/Backend/Modules/Commerce/Layout/Templates/EditOrderStatus.html.twig
@@ -55,7 +55,7 @@
                         <span class="modal-title h4">{{ 'lbl.Delete'|trans|ucfirst }}</span>
                     </div>
                     <div class="modal-body">
-                        <p>{{ 'msg.ConfirmDelete'|trans|format(orderStatus.title)|raw }}</p>
+                        <p>{{ 'msg.ConfirmDelete'|trans|format(orderStatus.title|escape)|raw }}</p>
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-default" data-dismiss="modal">

--- a/src/Backend/Modules/Commerce/Layout/Templates/EditProductOption.html.twig
+++ b/src/Backend/Modules/Commerce/Layout/Templates/EditProductOption.html.twig
@@ -115,7 +115,7 @@
             <span class="modal-title h4">{{ 'lbl.Delete'|trans|ucfirst }}</span>
           </div>
           <div class="modal-body">
-            <p>{{ 'msg.ConfirmDelete'|trans|format(productOption.title)|raw }}</p>
+            <p>{{ 'msg.ConfirmDelete'|trans|format(productOption.title|escape)|raw }}</p>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-default" data-dismiss="modal">

--- a/src/Backend/Modules/Commerce/Layout/Templates/EditProductOptionValue.html.twig
+++ b/src/Backend/Modules/Commerce/Layout/Templates/EditProductOptionValue.html.twig
@@ -154,7 +154,7 @@
             <span class="modal-title h4">{{ 'lbl.Delete'|trans|ucfirst }}</span>
           </div>
           <div class="modal-body">
-            <p>{{ 'msg.ConfirmDelete'|trans|format(productOptionValue.title)|raw }}</p>
+            <p>{{ 'msg.ConfirmDelete'|trans|format(productOptionValue.title|escape)|raw }}</p>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-default" data-dismiss="modal">

--- a/src/Backend/Modules/Commerce/Layout/Templates/EditSpecification.html.twig
+++ b/src/Backend/Modules/Commerce/Layout/Templates/EditSpecification.html.twig
@@ -71,7 +71,7 @@
                         <span class="modal-title h4">{{ 'lbl.Delete'|trans|ucfirst }}</span>
                     </div>
                     <div class="modal-body">
-                        <p>{{ 'msg.ConfirmDelete'|trans|format(specification.title)|raw }}</p>
+                        <p>{{ 'msg.ConfirmDelete'|trans|format(specification.title|escape)|raw }}</p>
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-default" data-dismiss="modal">

--- a/src/Backend/Modules/Commerce/Layout/Templates/EditSpecificationValue.html.twig
+++ b/src/Backend/Modules/Commerce/Layout/Templates/EditSpecificationValue.html.twig
@@ -63,7 +63,7 @@
                         <span class="modal-title h4">{{ 'lbl.Delete'|trans|ucfirst }}</span>
                     </div>
                     <div class="modal-body">
-                        <p>{{ 'msg.ConfirmDelete'|trans|format(specificationValue.value)|raw }}</p>
+                        <p>{{ 'msg.ConfirmDelete'|trans|format(specificationValue.value|escape)|raw }}</p>
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-default" data-dismiss="modal">

--- a/src/Backend/Modules/Commerce/Layout/Templates/EditStockStatus.html.twig
+++ b/src/Backend/Modules/Commerce/Layout/Templates/EditStockStatus.html.twig
@@ -55,7 +55,7 @@
                         <span class="modal-title h4">{{ 'lbl.Delete'|trans|ucfirst }}</span>
                     </div>
                     <div class="modal-body">
-                        <p>{{ 'msg.ConfirmDelete'|trans|format(stockStatus.title)|raw }}</p>
+                        <p>{{ 'msg.ConfirmDelete'|trans|format(stockStatus.title|escape)|raw }}</p>
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-default" data-dismiss="modal">

--- a/src/Backend/Modules/Commerce/Layout/Templates/EditVat.html.twig
+++ b/src/Backend/Modules/Commerce/Layout/Templates/EditVat.html.twig
@@ -56,7 +56,7 @@
                         <span class="modal-title h4">{{ 'lbl.Delete'|trans|ucfirst }}</span>
                     </div>
                     <div class="modal-body">
-                        <p>{{ 'msg.ConfirmDelete'|trans|format(vat.title)|raw }}</p>
+                        <p>{{ 'msg.ConfirmDelete'|trans|format(vat.title|escape)|raw }}</p>
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-default" data-dismiss="modal">

--- a/src/Frontend/Modules/Commerce/Layout/Templates/FormLayout.html.twig
+++ b/src/Frontend/Modules/Commerce/Layout/Templates/FormLayout.html.twig
@@ -43,7 +43,7 @@
     <div class="form-group">
       {{ form_widget(form.file) }}
       {% if help_text_message %}
-        <div class="help-text">{{ help_text_message|trans|format(help_text_argument) }}</div>
+        <div class="help-text">{{ help_text_message|trans|format(help_text_argument|escape)|raw }}</div>
       {% endif %}
       {{ form_errors(form.file) }}
     </div>

--- a/src/Frontend/Modules/Commerce/Layout/Templates/Search.html.twig
+++ b/src/Frontend/Modules/Commerce/Layout/Templates/Search.html.twig
@@ -66,7 +66,7 @@
 {% if productCount == 0 %}
     <div class="col-lg-6 col-md-7 col-sm-9 col-xs-12 product-overview">
         {% if searchTerm %}
-            <p>{{ 'msg.NoSearchResultsFor'|trans|format(searchTerm) }}</p>
+            <p>{{ 'msg.NoSearchResultsFor'|trans|format(searchTerm|escape)|raw }}</p>
         {% else %}
             <p>{{ 'msg.EnterSearchTerm'|trans }}</p>
         {% endif %}


### PR DESCRIPTION
### Description

In the admin section in Commerce -> Shop settings -> Stock statuses -> Edit stock statuses one can add XSS payloads. After adding XSS payloads when a user is visiting Commerce -> Shop settings -> Stock statuses the JavaScript code will be run.


### Proof of Concept

Go to Commerce -> Shop settings -> Stock statuses -> Edit stock statuses and add XSS, e.g.

Available<script>alert(1);</script>

### Impact

Running JavaScript code.
