### PR TITLE
Add missing LiipImagineBundle filter to instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -81,6 +81,11 @@ liip_imagine:
                 auto_rotate: ~
                 strip: ~
                 scale: { dim: [ 300, 380 ] }
+        product_thumbnail_square:
+            filters:
+                auto_rotate: ~
+                strip: ~
+                thumbnail: { size: [ 250, 250 ], mode: outbound }
         product_large:
             filters:
                 auto_rotate: ~


### PR DESCRIPTION
Adds the recently added thumbnail square filter to the installation instructions