### PR TITLE
Add CommerceDelivery module

### DIFF
--- a/src/Backend/Modules/CommerceDelivery/Actions/Edit.php
+++ b/src/Backend/Modules/CommerceDelivery/Actions/Edit.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Backend\Modules\CommerceDelivery\Actions;
+
+use Backend\Core\Engine\Model;
+use Backend\Core\Language\Locale;
+use Backend\Modules\Commerce\Domain\ShipmentMethod\Edit as ShipmentBaseActionEdit;
+use Backend\Modules\Commerce\Domain\ShipmentMethod\ShipmentMethod;
+use Backend\Modules\Commerce\Domain\ShipmentMethod\ShipmentMethodDataTransferObject;
+use Backend\Modules\CommerceDelivery\Domain\Delivery\Command\UpdateDeliveryShipmentMethod;
+use Backend\Modules\CommerceDelivery\Domain\Delivery\DeliveryShipmentMethodType;
+use Symfony\Component\Form\Form;
+
+class Edit extends ShipmentBaseActionEdit
+{
+    // Needed to override the module because we render this action inside the Commerce module.
+    protected string $module = 'CommerceDelivery';
+
+    public function execute(): void
+    {
+        parent::execute();
+
+        $shipmentMethod = $this->getShipmentMethod();
+
+        $countries = [];
+        foreach ($this->get('commerce.repository.country')->findAll() as $country) {
+            $countries[] = [
+                'id' => $country->getId(),
+                'name' => $country->getName(),
+            ];
+        }
+
+        $form = $this->getForm($shipmentMethod, $countries);
+
+        if (!$form->isSubmitted() || !$form->isValid()) {
+            $this->template->assign('form', $form->createView());
+            $this->template->assign('countries', $countries);
+
+            return;
+        }
+
+        $this->updateShipmentMethod($form);
+
+        $this->redirect(
+            Model::createUrlForAction(
+                'ShipmentMethods',
+                null,
+                null,
+                [
+                    'report' => 'edited',
+                    'var' => '',
+                    'highlight' => 'row-' . $shipmentMethod->getId(),
+                ]
+            )
+        );
+    }
+
+    private function getForm(ShipmentMethod $shipmentMethod, $countries = []): Form
+    {
+        $data = $this->shipmentMethodSettingsRepository->getShipmentMethodData(
+            new UpdateDeliveryShipmentMethod($shipmentMethod, Locale::workingLocale())
+        );
+        $form = $this->createForm(
+            DeliveryShipmentMethodType::class,
+            $data,
+            [
+                'entityManager' => $this->entityManager,
+                'countries' => $countries,
+            ]
+        );
+
+        $form->handleRequest($this->getRequest());
+
+        return $form;
+    }
+
+    private function updateShipmentMethod(Form $form): void
+    {
+        // Get the form data
+        /** @var ShipmentMethodDataTransferObject $data */
+        $data = $form->getData();
+
+        // The command bus will handle the saving of the shipment method in the database.
+        $this->commandBus->handle($data);
+    }
+}

--- a/src/Backend/Modules/CommerceDelivery/DependencyInjection/CommerceDeliveryExtension.php
+++ b/src/Backend/Modules/CommerceDelivery/DependencyInjection/CommerceDeliveryExtension.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Backend\Modules\CommerceDelivery\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+/**
+ * This is the class that loads and manages your bundle configuration
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
+ *
+ * @codeCoverageIgnore
+ */
+class CommerceDeliveryExtension extends Extension implements PrependExtensionInterface
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('services.yml');
+    }
+
+    public function prepend(ContainerBuilder $container): void
+    {
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('doctrine.yml');
+    }
+}

--- a/src/Backend/Modules/CommerceDelivery/Domain/Delivery/Checkout/Quote.php
+++ b/src/Backend/Modules/CommerceDelivery/Domain/Delivery/Checkout/Quote.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Backend\Modules\CommerceDelivery\Domain\Delivery\Checkout;
+
+use Backend\Modules\Commerce\Domain\ShipmentMethod\Checkout\ShipmentMethodQuote;
+use Backend\Modules\Commerce\Domain\Vat\Exception\VatNotFound;
+use Backend\Modules\Commerce\Domain\Vat\Vat;
+use Money\Money;
+
+class Quote extends ShipmentMethodQuote
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getQuote(): array
+    {
+        // General setting
+        $availablePaymentMethods = $this->shipmentMethodSettingsRepository->getSetting('CommerceDelivery', 'availablePaymentMethods');
+
+        // Country specific shipment methods
+        $shipmentMethods = $this->shipmentMethodSettingsRepository->getSetting('CommerceDelivery', 'shipmentMethods');
+        $enabledShipmentMethods = [];
+
+        foreach ($shipmentMethods as $shipmentMethod) {
+            if (!$shipmentMethod['enabled']) {
+                continue;
+            }
+
+            $enabledShipmentMethods[$shipmentMethod['label']] = [
+                'label' => "{$shipmentMethod['label']} ({$this->moneyFormatter->localizedFormatMoney($shipmentMethod['price'])})",
+                'name' => $shipmentMethod['label'],
+                'price' => $shipmentMethod['price'],
+                'vat' => $this->getVatPrice($shipmentMethod['price']),
+                'available_payment_methods' => $availablePaymentMethods,
+            ];
+        }
+
+        if ($enabledShipmentMethods) {
+            return $enabledShipmentMethods;
+        } else {
+            // No enabled country-specific methods -> fallback to default delivery pricing
+            /** @var Money $price */
+            $price = $this->shipmentMethodSettingsRepository->getSetting('CommerceDelivery', 'price');
+
+            return [
+                $this->name => [
+                    'label' => "{$this->name} ({$this->moneyFormatter->localizedFormatMoney($price)})",
+                    'name' => $this->name,
+                    'price' => $price,
+                    'vat' => $this->getVatPrice($price),
+                    'available_payment_methods' => $availablePaymentMethods,
+                ],
+            ];
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getVatPrice(Money $price): array
+    {
+        $vatId = $this->shipmentMethodSettingsRepository->getSetting('CommerceDelivery', 'vatId');
+        $vat = $this->vatRepository->find($vatId);
+        if (!$vat instanceof Vat) {
+            throw VatNotFound::forEmptyId();
+        }
+
+        return [
+            'id' => $vat->getId(),
+            'price' => $price->multiply($vat->getAsPercentage()),
+        ];
+    }
+}

--- a/src/Backend/Modules/CommerceDelivery/Domain/Delivery/Command/UpdateDeliveryShipmentMethod.php
+++ b/src/Backend/Modules/CommerceDelivery/Domain/Delivery/Command/UpdateDeliveryShipmentMethod.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Backend\Modules\CommerceDelivery\Domain\Delivery\Command;
+
+use Backend\Modules\CommerceDelivery\Domain\Delivery\DeliveryShipmentMethodDataTransferObject;
+
+class UpdateDeliveryShipmentMethod extends DeliveryShipmentMethodDataTransferObject
+{
+}

--- a/src/Backend/Modules/CommerceDelivery/Domain/Delivery/Command/UpdateDeliveryShipmentMethodHandler.php
+++ b/src/Backend/Modules/CommerceDelivery/Domain/Delivery/Command/UpdateDeliveryShipmentMethodHandler.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Backend\Modules\CommerceDelivery\Domain\Delivery\Command;
+
+use Backend\Modules\Commerce\Domain\ShipmentMethod\Command\UpdateShipmentMethodHandler;
+
+class UpdateDeliveryShipmentMethodHandler extends UpdateShipmentMethodHandler
+{
+}

--- a/src/Backend/Modules/CommerceDelivery/Domain/Delivery/DeliveryShipmentMethodDataTransferObject.php
+++ b/src/Backend/Modules/CommerceDelivery/Domain/Delivery/DeliveryShipmentMethodDataTransferObject.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Backend\Modules\CommerceDelivery\Domain\Delivery;
+
+use Backend\Core\Language\Locale;
+use Backend\Modules\Commerce\Domain\ShipmentMethod\ShipmentMethod;
+use Backend\Modules\Commerce\Domain\ShipmentMethod\ShipmentMethodDataTransferObject;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Money\Money;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class DeliveryShipmentMethodDataTransferObject extends ShipmentMethodDataTransferObject
+{
+    /**
+     * @Assert\NotBlank(message="err.FieldIsRequired")
+     */
+    public ?Money $price;
+
+    /**
+     * @Assert\NotBlank(message="err.FieldIsRequired")
+     */
+    public ?int $vatId;
+
+    public ?Collection $availablePaymentMethods;
+
+    public $shipmentMethods = [];
+
+    public function __construct(ShipmentMethod $shipmentMethod = null, Locale $locale)
+    {
+        $this->name = 'Delivery shipment'; // default name filled in the UI
+        $this->module = 'CommerceDelivery';
+        parent::__construct($shipmentMethod, $locale);
+        $this->price = null;
+        $this->vatId = null;
+        $this->availablePaymentMethods = new ArrayCollection();
+    }
+
+    public function __set($key, $value)
+    {
+        $this->shipmentMethods[$key] = $value;
+    }
+
+    public function __get($key)
+    {
+        if (!isset($this->shipmentMethods[$key])) {
+            return null;
+        }
+
+        return $this->shipmentMethods[$key];
+    }
+}

--- a/src/Backend/Modules/CommerceDelivery/Domain/Delivery/DeliveryShipmentMethodType.php
+++ b/src/Backend/Modules/CommerceDelivery/Domain/Delivery/DeliveryShipmentMethodType.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Backend\Modules\CommerceDelivery\Domain\Delivery;
+
+use Backend\Modules\Commerce\Domain\ShipmentMethod\ShipmentMethodType;
+use Backend\Modules\Commerce\Domain\Vat\Vat;
+use Backend\Modules\Commerce\Domain\Vat\VatTransformer;
+use Doctrine\ORM\EntityRepository;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Tbbc\MoneyBundle\Form\Type\MoneyType;
+
+class DeliveryShipmentMethodType extends ShipmentMethodType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        parent::buildForm($builder, $options);
+
+        $builder
+            ->add('name', TextType::class, [
+                'required' => true,
+                'label' => 'lbl.Name',
+            ])
+            ->add('price', MoneyType::class, [
+                'required' => true,
+                'label' => 'lbl.Price',
+            ])
+            ->add('vatId', EntityType::class, [
+                'required' => true,
+                'label' => 'lbl.Vat',
+                'class' => Vat::class,
+                'query_builder' => function (EntityRepository $er) {
+                    return $er->createQueryBuilder('i')
+                        ->orderBy('i.sequence', 'ASC');
+                },
+                'choice_label' => 'title',
+            ]);
+
+        $builder
+            ->get('vatId')
+            ->addModelTransformer(new VatTransformer($options['entityManager']));
+
+        foreach ($options['countries'] as $country) {
+            $builder->add(
+                $builder->create(
+                    $country['id'],
+                    FormType::class,
+                    [
+                        'required' => false,
+                        'by_reference' => false,
+                        'label' => '',
+                    ]
+                )->add(
+                    'enabled',
+                    ChoiceType::class,
+                    [
+                        'required' => false,
+                        'label' => 'lbl.Enabled',
+                        'placeholder' => false,
+                        'choices' => [
+                            'lbl.No' => false,
+                            'lbl.Yes' => true,
+                        ],
+                    ]
+                )->add(
+                    'label',
+                    TextType::class,
+                    [
+                        'required' => false,
+                        'label' => 'lbl.Name',
+                    ]
+                )->add(
+                    'price',
+                    MoneyType::class,
+                    [
+                        'required' => true,
+                        'label' => 'lbl.Price',
+                    ]
+                )
+            );
+        }
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults(
+            [
+                'countries' => [],
+            ]
+        );
+
+        parent::configureOptions($resolver);
+    }
+}

--- a/src/Backend/Modules/CommerceDelivery/Domain/Delivery/Factory/DeliveryShipmentMethodFactory.php
+++ b/src/Backend/Modules/CommerceDelivery/Domain/Delivery/Factory/DeliveryShipmentMethodFactory.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Backend\Modules\CommerceDelivery\Domain\Delivery\Factory;
+
+use Backend\Core\Language\Locale;
+use Backend\Modules\Commerce\Domain\ShipmentMethod\ShipmentMethod;
+use Backend\Modules\Commerce\Domain\ShipmentMethod\ShipmentMethodRepository;
+use Backend\Modules\CommerceDelivery\Domain\Delivery\DeliveryShipmentMethodDataTransferObject;
+use Zenstruck\Foundry\ModelFactory;
+use Zenstruck\Foundry\Proxy;
+use Zenstruck\Foundry\RepositoryProxy;
+
+/**
+ * @extends ModelFactory<ShipmentMethod>
+ *
+ * @method static ShipmentMethod[]|Proxy[] createMany(int $number, array|callable $attributes = [])
+ * @method static ShipmentMethodRepository|RepositoryProxy repository()
+ * @method ShipmentMethod|Proxy create(array|callable $attributes = [])
+ *
+ * @see: https://symfony.com/index.php/bundles/ZenstruckFoundryBundle/current/index.html
+ * @codeCoverageIgnore
+ */
+final class DeliveryShipmentMethodFactory extends ModelFactory
+{
+    /**
+     * Our entities use private properties, no setters and a private constructor. Therefore, we have to use a DTO
+     * object to instantiate our Entity.
+     */
+    protected function initialize(): self
+    {
+        return $this
+            ->instantiateWith(function (array $attributes) {
+                $dto = new DeliveryShipmentMethodDataTransferObject(null, Locale::fromString('en'));
+                $dto->name = $attributes['name'];
+                $dto->isEnabled = $attributes['isEnabled'];
+                $dto->vatId = $attributes['vatId'];
+
+                return ShipmentMethod::fromDataTransferObject($dto);
+            });
+    }
+
+    protected function getDefaults(): array
+    {
+        return [
+            'name' => 'Deliver shipment',
+            'isEnabled' => true,
+            'vatId' => 1,
+        ];
+    }
+
+    protected static function getClass(): string
+    {
+        return ShipmentMethod::class;
+    }
+
+    public function isEnabled(): self
+    {
+        return $this->addState(['isEnabled' => true]);
+    }
+
+    public function isDisabled(): self
+    {
+        return $this->addState(['isEnabled' => false]);
+    }
+
+    public function withOrderInitId(int $orderInitId): self
+    {
+        return $this->addState(['orderInitId' => (string) $orderInitId]);
+    }
+}

--- a/src/Backend/Modules/CommerceDelivery/Installer/Data/locale.xml
+++ b/src/Backend/Modules/CommerceDelivery/Installer/Data/locale.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale>
+  <Backend>
+    <Core>
+      <item type="label" name="CommerceDelivery">
+        <translation language="nl"><![CDATA[Pakket leveren]]></translation>
+        <translation language="en"><![CDATA[Deliver shipment]]></translation>
+      </item>
+    </Core>
+  </Backend>
+</locale>

--- a/src/Backend/Modules/CommerceDelivery/Installer/Installer.php
+++ b/src/Backend/Modules/CommerceDelivery/Installer/Installer.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Backend\Modules\CommerceDelivery\Installer;
+
+use Backend\Core\Installer\ModuleInstaller;
+use Backend\Core\Language\Language;
+
+class Installer extends ModuleInstaller
+{
+    public function install(): void
+    {
+        $this->addModule('CommerceDelivery');
+        $this->importLocale(__DIR__ . '/Data/locale.xml');
+        $this->registerCommerceShipmentMethod($this->getModule());
+    }
+
+    /**
+     * Register this module in the Commerce module as available shipment method
+     */
+    private function registerCommerceShipmentMethod(string $module): void
+    {
+        foreach ($this->getLanguages() as $language) {
+            Language::setLocale($language);
+            $name = ucfirst(Language::lbl($this->getModule()));
+            $this->getDatabase()->execute(
+                'INSERT INTO commerce_shipment_methods (name, module, language) VALUES (?, ?, ?)',
+                [$name, $module, $language]
+            );
+        }
+    }
+}

--- a/src/Backend/Modules/CommerceDelivery/Layout/Edit.html.twig
+++ b/src/Backend/Modules/CommerceDelivery/Layout/Edit.html.twig
@@ -1,0 +1,78 @@
+{% extends 'Layout/Templates/base.html.twig' %}
+{% form_theme form with ["Commerce/Layout/Templates/FormHelper.html.twig"] %}
+
+{% block actionbar %}
+
+{% endblock %}
+
+{% block content %}
+  {{ form_start(form) }}
+
+  <div class="row fork-module-content">
+    <div class="col-md-12">
+      <div class="form-group">
+        <label for="name" class="control-label">{{ 'lbl.Name'|trans|ucfirst }}</label>
+        {{ form_widget(form.name, {'attr' : {'class' : 'title'}}) }}
+      </div>
+    </div>
+  </div>
+
+  <div class="row fork-module-content">
+    <div class="col-md-12">
+      <div role="tabpanel">
+        <ul class="nav nav-tabs" role="tablist">
+          <li role="presentation" class="active">
+            <a href="#tabContent" aria-controls="tabContent" role="tab"
+               data-toggle="tab">{{ 'lbl.Content'|trans|ucfirst }}</a>
+          </li>
+          {% for country in countries %}
+            <li role="presentation">
+              <a href="#tabCountry{{ country.id }}" aria-controls="tabContent" role="tab"
+                 data-toggle="tab">{{ country.name }}</a>
+            </li>
+          {% endfor %}
+        </ul>
+        <div class="tab-content">
+          <div role="tabpanel" class="tab-pane active" id="tabContent">
+            <div class="row">
+              <div class="col-md-8">
+                <div class="panel panel-default">
+                  <div class="panel-heading">
+                    <p>{{ 'lbl.DefaultSettings'|trans|ucfirst }}</p>
+                  </div>
+                  <div class="panel-body">
+                    <div class="form-group">
+                      {{ form_row(form.price) }}
+                      {{ form_row(form.vatId) }}
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="col-md-4">
+                {{ form_row(form.isEnabled) }}
+                {{ form_row(form.availablePaymentMethods) }}
+              </div>
+            </div>
+          </div>
+          {% for country in countries %}
+            <div role="tabpanel" class="tab-pane" id="tabCountry{{ country.id }}">
+              {{ form_widget(form[country.id]) }}
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row fork-page-actions">
+    <div class="col-md-12">
+      <div class="btn-toolbar">
+        <div class="btn-group pull-right" role="group">
+          <button id="editButton" type="submit" name="edit" class="btn btn-primary">
+            <span class="fa fa-floppy-o"></span>{{ 'lbl.Save'|trans|ucfirst }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  {{ form_end(form) }}
+{% endblock %}

--- a/src/Backend/Modules/CommerceDelivery/Resources/config/commands.yml
+++ b/src/Backend/Modules/CommerceDelivery/Resources/config/commands.yml
@@ -1,0 +1,8 @@
+services:
+    commerce.handler.update_shipment_method_delivery:
+        class: Backend\Modules\CommerceDelivery\Domain\Delivery\Command\UpdateDeliveryShipmentMethodHandler
+        arguments:
+            - "@commerce.repository.shipment_method"
+            - "@fork.settings"
+        tags:
+            - { name: command_handler, handles: Backend\Modules\CommerceDelivery\Domain\Delivery\Command\UpdateDeliveryShipmentMethod }

--- a/src/Backend/Modules/CommerceDelivery/Resources/config/services.yml
+++ b/src/Backend/Modules/CommerceDelivery/Resources/config/services.yml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: commands.yml }

--- a/src/Backend/Modules/CommerceDelivery/Tests/Actions/EditTest.php
+++ b/src/Backend/Modules/CommerceDelivery/Tests/Actions/EditTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Backend\Modules\CommerceDelivery\Tests\Actions;
+
+use Backend\Core\Tests\BackendWebTestCase;
+use Backend\Modules\Commerce\Domain\PaymentMethod\Factory\PaymentMethodFactory;
+use Backend\Modules\Commerce\Domain\Vat\Factory\VatFactory;
+use Backend\Modules\Extensions\Engine\Model as BackendExtensionsModel;
+use Symfony\Bundle\FrameworkBundle\Client;
+use Zenstruck\Foundry\Test\Factories;
+
+class EditTest extends BackendWebTestCase
+{
+    use Factories;
+
+    // Required by Foundry to know when kernel has booted. Can be removed in later Symfony versions.
+    protected static bool $booted = false;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        static::$booted = true;
+
+        // Install the module(s)
+        BackendExtensionsModel::installModule('Commerce');
+        BackendExtensionsModel::installModule('CommerceDelivery');
+    }
+
+    /** @test */
+    public function it_can_edit_the_shipment_method(Client $client): void
+    {
+        $this->login($client);
+
+        // Create a few objects to link the shipment method to
+        $vat = VatFactory::new()->create();
+        PaymentMethodFactory::createMany(3);
+
+        self::assertPageLoadedCorrectly(
+            $client,
+            '/private/en/commerce/edit_shipment_method?id=1',
+            ['form name="pickup_shipment_method" method="post"']
+        );
+
+        // Edit the shipment method and submit the form
+        $form = $this->getFormForSubmitButton($client, 'Save');
+        $client->submit($form, [
+            'pickup_shipment_method[name]' => 'Delivery (EditTest)',
+            'pickup_shipment_method[price][tbbc_amount]' => 10.00,
+            'pickup_shipment_method[vatId]' => (string) $vat->getId(),
+            'pickup_shipment_method[isEnabled]' => true,
+            'pickup_shipment_method[availablePaymentMethods][0]' => true,
+            'pickup_shipment_method[availablePaymentMethods][1]' => true,
+            'pickup_shipment_method[availablePaymentMethods][2]' => true,
+        ]);
+        $client->followRedirect();
+
+        // Receive a 200 OK and be redirected to the index page
+        self::assertIs200($client);
+        self::assertCurrentUrlContains($client, '/private/en/commerce/shipment_methods?report=edited');
+        self::assertResponseHasContent($client->getResponse(), 'Delivery (EditTest)');
+
+        // Open the edit page again and assert that the values were saved correctly
+        $client->request('GET', '/private/en/commerce/edit_shipment_method?id=1');
+        self::assertResponseHasContent($client->getResponse(), $vat->getTitle());
+        $formValues = $this->getFormForSubmitButton($client, 'Save')->getValues();
+        self::assertEquals('Delivery (EditTest)', $formValues['pickup_shipment_method[name]']);
+        self::assertEquals(10.00, $formValues['pickup_shipment_method[price][tbbc_amount]']);
+        self::assertEquals('1', $formValues['pickup_shipment_method[isEnabled]']);
+    }
+}

--- a/src/Backend/Modules/CommerceDelivery/Tests/Domain/Delivery/Checkout/QuoteTest.php
+++ b/src/Backend/Modules/CommerceDelivery/Tests/Domain/Delivery/Checkout/QuoteTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Backend\Modules\CommerceDelivery\Tests\Domain\Delivery\Checkout;
+
+use Backend\Modules\Commerce\Domain\Cart\Cart;
+use Backend\Modules\Commerce\Domain\Cart\Factory\CartFactory;
+use Backend\Modules\Commerce\Domain\PaymentMethod\PaymentMethod;
+use Backend\Modules\Commerce\Domain\Settings\CommerceModuleSettingsRepository;
+use Backend\Modules\Commerce\Domain\Vat\Exception\VatNotFound;
+use Backend\Modules\Commerce\Domain\Vat\Factory\VatFactory;
+use Backend\Modules\Commerce\Domain\Vat\Vat;
+use Backend\Modules\Commerce\Domain\Vat\VatRepository;
+use Backend\Modules\CommerceCashOnDelivery\Domain\CashOnDelivery\Factory\CashOnDeliveryPaymentMethodFactory;
+use Backend\Modules\CommerceDelivery\Domain\Delivery\Checkout\Quote;
+use Common\ModulesSettings;
+use Doctrine\Common\Collections\ArrayCollection;
+use ForkCMS\App\BaseModel;
+use Money\Money;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Tbbc\MoneyBundle\Formatter\MoneyFormatter;
+use Zenstruck\Foundry\Test\Factories;
+
+class QuoteTest extends TestCase
+{
+    use Factories;
+
+    protected function setUp(): void
+    {
+        // Set globals
+        if (!defined('FRONTEND_LANGUAGE')) {
+            define('FRONTEND_LANGUAGE', 'en');
+        }
+
+        // The ProductDTO reaches out to the container for fork settings and the product repository, so we have to mock this.
+        $forkSettings = $this->getMockBuilder(ModulesSettings::class)->disableOriginalConstructor()->getMock();
+        $forkSettings->method('get')->willReturn(['en']); // both for language and active_language
+
+        // Let the container return our mocks
+        $container = $this->getMockBuilder(ContainerInterface::class)->disableOriginalConstructor()->getMock();
+        $container->method('getParameter')->with('site.default_language')->willReturn('en');
+        $container
+            ->method('get')
+            ->willReturnMap([
+                ['fork.settings', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $forkSettings],
+            ]);
+        BaseModel::setContainer($container);
+    }
+
+    /** @test */
+    public function it_returns_a_quote_for_a_delivery_shipment(): void
+    {
+        /** @var PaymentMethod $paymentMethod */
+        $paymentMethod = CashOnDeliveryPaymentMethodFactory::new()->create()->object();
+        /** @var Cart $cart */
+        $cart = CartFactory::new()->create()->object();
+        $address = $cart->getShipmentAddress();
+        $vat = VatFactory::new()->create()->forceSet('id', 1)->object();
+
+        // Mock the repository that fetches payment method & shipment method data from modules_settings
+        $commerceModuleSettingsRepositoryMock = $this->getModuleSettingsMock(
+            new ArrayCollection([$paymentMethod]),
+            Money::EUR(0),
+            $vat
+        );
+        $vatRepositoryMock = $this->getMockBuilder(VatRepository::class)->disableOriginalConstructor()->getMock();
+        $vatRepositoryMock->method('find')->willReturn($vat);
+
+        $checkoutQuote = new Quote(
+            'Delivery shipment',
+            $cart,
+            $address,
+            $commerceModuleSettingsRepositoryMock,
+            new MoneyFormatter(),
+            $vatRepositoryMock
+        );
+        $this->assertEquals([
+            'Deliver shipment' => [
+                'label' => 'Deliver shipment (€0.00)',
+                'name' => 'Deliver shipment',
+                'price' => Money::EUR(0),
+                'vat' => ['id' => 1, 'price' => Money::EUR(0)],
+                'available_payment_methods' => new ArrayCollection([$paymentMethod]),
+            ],
+        ], $checkoutQuote->getQuote());
+    }
+
+    /** @test */
+    public function it_should_throw_an_exception_if_vat_is_invalid(): void
+    {
+        /** @var Cart $cart */
+        $cart = CartFactory::new()->create()->object();
+        $address = $cart->getShipmentAddress();
+
+        // Mock the repository that fetches payment method & shipment method data from modules_settings
+        $commerceModuleSettingsRepositoryMock = $this->getModuleSettingsMock(
+            new ArrayCollection(),
+            Money::EUR(0),
+            null // invalid VAT
+        );
+        $vatRepositoryMock = $this->getMockBuilder(VatRepository::class)->disableOriginalConstructor()->getMock();
+
+        $checkoutQuote = new Quote(
+            'Delivery shipment',
+            $cart,
+            $address,
+            $commerceModuleSettingsRepositoryMock,
+            new MoneyFormatter(),
+            $vatRepositoryMock
+        );
+        $this->expectException(VatNotFound::class);
+        $checkoutQuote->getQuote();
+    }
+
+    private function getModuleSettingsMock(ArrayCollection $availablePaymentMethods, Money $price, ?Vat $vat)
+    {
+        $commerceModuleSettingsRepositoryMock = $this->getMockBuilder(CommerceModuleSettingsRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $commerceModuleSettingsRepositoryMock
+            ->method('getSetting')
+            ->willReturnCallback(function ($moduleName, $property) use ($availablePaymentMethods, $price, $vat) {
+                switch ($property) {
+                    case 'availablePaymentMethods':
+                        return $availablePaymentMethods;
+                    case 'price':
+                        return $price;
+                    case 'vat':
+                        return $vat;
+                }
+            });
+
+        return $commerceModuleSettingsRepositoryMock;
+    }
+}

--- a/src/Backend/Modules/CommerceDelivery/info.xml
+++ b/src/Backend/Modules/CommerceDelivery/info.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module>
+  <name>CommerceDelivery</name>
+  <version>1.0.0</version>
+  <requirements>
+    <minimum_version>3.0.0</minimum_version>
+  </requirements>
+  <description>
+    <![CDATA[
+      Shipment provider module for Fork CMS Commerce. Handle basic order deliveries in your website.
+    ]]>
+  </description>
+  <authors>
+    <author>
+      <name><![CDATA[Alessandro Craeye]]></name>
+    </author>
+  </authors>
+</module>


### PR DESCRIPTION
Adds a new shipment method where the shipping cost can be set per country. If no country is enabled it falls back to the default delivery pricing.

Validation still needs to be added so only the available country / method is shown based on the shipment address provided by the customer.